### PR TITLE
fix: remove obsolete Streamlit dependencies from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,10 +21,6 @@ httpx>=0.25.0
 # OpenAI SDK for Moonshot AI (Kimi API)
 openai>=1.0.0
 
-# Streamlit for Web Interface
-streamlit>=1.28.0
-streamlit-chat>=0.1.1
-
 # Image Processing (for medical imaging)
 Pillow>=8.3.0
 opencv-python-headless>=4.5.0


### PR DESCRIPTION
These are V1 leftovers that are no longer needed since MedX uses Reflex for the UI.

Issue: #3