### PR TITLE
fix: render dosage result inline in calculator panel

### DIFF
--- a/ui/medex_ui/app.py
+++ b/ui/medex_ui/app.py
@@ -2271,6 +2271,23 @@ def dosage_calculator_panel() -> rx.Component:
             ),
             rx.fragment(),
         ),
+        # Inline dosage result display
+        rx.cond(
+            MedeXState.dosage_result != "",
+            rx.box(
+                rx.markdown(
+                    MedeXState.dosage_result,
+                    color=THEME.TEXT_PRIMARY,
+                ),
+                padding=Space.S4,
+                border_radius=Radius.MD,
+                background=THEME.PRIMARY_50,
+                border=f"1px solid {THEME.PRIMARY_200}",
+                width="100%",
+                margin_top=Space.S2,
+            ),
+            rx.fragment(),
+        ),
         # Artifact Catalog Grid for Dosage
         dosage_artifacts_grid(),
         gap=Space.S4,


### PR DESCRIPTION
## Summary

Closes #16

Adds inline display of dosage calculation results directly in `dosage_calculator_panel()` using `rx.cond(MedeXState.dosage_result)`. Previously, the computed dosage was only accessible through the artifact card modal ("Ver Más").

## Changes

### `ui/medex_ui/app.py`
- Added `rx.cond(MedeXState.dosage_result != "", rx.box(rx.markdown(...)))` block between the error display and the artifacts grid
- Result renders with `rx.markdown()` for proper formatting of the dosage fields
- Styled with `THEME.PRIMARY_50` background and border to match the panel aesthetic

## Before/After

| Before | After |
|--------|-------|
| User clicks Calculate → sees generic artifact card title | User clicks Calculate → result (dose, frequency, max daily, warnings) shown immediately inline |
| Must click "Ver Más" on artifact card to see actual values | Artifact card still available for modal view, but values are visible without extra interaction |

## Technical Details

- `MedeXState.dosage_result` (str) is already populated correctly by `_format_dosage_result()` in `state.py`
- No state changes needed — only rendering was missing
- The `rx.cond` pattern matches Error/Loading patterns already used in the panel